### PR TITLE
Feat: Add bottom and top center positioning for popup stack

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -43,14 +43,45 @@ function applyConfigStyles() {
     }
   `;
 
-  // Anchor the popup stack to the configured corner with the configured offsets.
+  // Anchor the popup stack to the configured position with the configured offsets.
   const position = config.position || "top-left";
   const [vertical, horizontal] = position.split("-");
-  popupArea.style.top = vertical === "top" ? `${num(config.topOffset, 0)}px` : "auto";
-  popupArea.style.bottom = vertical === "bottom" ? `${num(config.bottomOffset, 0)}px` : "auto";
-  popupArea.style.left = horizontal === "left" ? `${num(config.leftOffset, 0)}px` : "auto";
-  popupArea.style.right = horizontal === "right" ? `${num(config.rightOffset, 0)}px` : "auto";
-  popupArea.style.alignItems = horizontal === "left" ? "flex-start" : "flex-end";
+
+  // Vertical anchoring
+  popupArea.style.bottom = "auto";
+  if (vertical === "top") {
+    popupArea.style.top = `${num(config.topOffset, 0)}px`;
+  } else if (vertical === "bottom") {
+    popupArea.style.top = "auto";
+    popupArea.style.bottom = `${num(config.bottomOffset, 0)}px`;
+  } else {
+    // center — vertically centered
+    popupArea.style.top = "50%";
+  }
+
+  // Horizontal anchoring
+  popupArea.style.right = "auto";
+  if (horizontal === "left") {
+    popupArea.style.left = `${num(config.leftOffset, 0)}px`;
+    popupArea.style.alignItems = "flex-start";
+  } else if (horizontal === "right") {
+    popupArea.style.left = "auto";
+    popupArea.style.right = `${num(config.rightOffset, 0)}px`;
+    popupArea.style.alignItems = "flex-end";
+  } else {
+    // center (or full center with no horizontal component)
+    popupArea.style.left = "50%";
+    popupArea.style.alignItems = "center";
+  }
+
+  // Transform: full center offsets both axes, edge-center offsets only X
+  if (horizontal === "center") {
+    popupArea.style.transform = "translateX(-50%)";
+  } else if (!horizontal) {
+    popupArea.style.transform = "translate(-50%, -50%)";
+  } else {
+    popupArea.style.transform = "none";
+  }
 }
 
 function renderPopup(popup) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -24,7 +24,7 @@ const SECTIONS = [
     title: "Position",
     fields: [
       { key: "showOnMonitor", type: "number", label: "Monitor index", hint: "0 = first monitor", min: 0, step: 1 },
-      { key: "position", type: "select", label: "Screen corner", options: ["top-left", "top-right", "bottom-left", "bottom-right"] },
+      { key: "position", type: "select", label: "Screen position", options: ["top-left", "top-center", "top-right", "center", "bottom-left", "bottom-center", "bottom-right"] },
       { key: "topOffset", type: "number", label: "Top offset (px)" },
       { key: "bottomOffset", type: "number", label: "Bottom offset (px)" },
       { key: "leftOffset", type: "number", label: "Left offset (px)" },


### PR DESCRIPTION
## Summary

Add 3 new screen position options — `center`, `top-center`, `bottom-center` — so users can anchor the popup stack to the middle of the screen, not just the four corners.

## Changes

**`src/settings.js`** — Expand the position selector from 4 to 7 options:

| Before | After |
|---|---|
| `top-left` / `top-right` / `bottom-left` / `bottom-right` | `top-left` / `top-center` / `top-right` / `center` / `bottom-left` / `bottom-center` / `bottom-right` |

**`src/overlay.js`** — Refactor `applyConfigStyles()` to handle the new positions generically:

- Split `position` into `vertical` (`top` / `bottom` / `center`) and `horizontal` (`left` / `right` / `center`) components, then apply each axis independently.
- **`top-center`** / **`bottom-center`**: anchored to the top or bottom edge with `topOffset`/`bottomOffset`, horizontally centered via `translateX(-50%)`, `alignItems: center`.
- **`center`**: fully centered — `top: 50%; left: 50%; transform: translate(-50%, -50%)`.
- Corner positions (`top-left`, `top-right`, `bottom-left`, `bottom-right`) behave exactly as before, with `transform` explicitly reset to `none` when switching away from a centered position.

## Notes
Though there is a plan "Drag and drop the popup to the desired position" in README, this PR implemented the basic requirement of `center-position` and did not make any breaking changes.